### PR TITLE
Enabled windows backtraces & added crates.io badge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ keywords = [
 ]
 
 [dependencies]
-backtrace = { version = "0.3.30", default-features = false, features = ["std", "libbacktrace", "libbacktrace", "libunwind", "dladdr"] }
+backtrace = { version = "0.3.30", default-features = false, features = ["std", "libbacktrace", "libbacktrace", "libunwind", "dladdr", "dbghelp"] }
 console = "0.7.7"
 syntect = { version = "3.2.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Crates.io](https://img.shields.io/crates/v/better-panic.svg)](https://crates.io/crates/better-panic)
+
 # better-panic
 
 `better-panic` gives you pretty backtraces for panics.


### PR DESCRIPTION
Before this change windows backtraces were missing:
![before](https://user-images.githubusercontent.com/5849037/60767495-efd65480-a0b0-11e9-95b5-bc4f4eee4a41.png)

After `Medium` verbosity:
![image](https://user-images.githubusercontent.com/5849037/60767832-2ada8700-a0b5-11e9-919b-3f248e4d4057.png)

After `Full` verbosity:
![after](https://user-images.githubusercontent.com/5849037/60767503-f82e8f80-a0b0-11e9-9513-5aa0d42f0e20.png)


I also added a crates.io badge as I was almost going to add it in my `.toml` as a git reference since I didn't think it's published.

