### PR TITLE
Upgraded backtrace version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ keywords = [
 ]
 
 [dependencies]
-backtrace = "0.3.37"
+backtrace = "0.3.73"
 console = { version = "0.15.0", default-features = false }
 syntect = { version = "4.6.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "better-panic"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>", "Joel Höner <athre0z@zyantific.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
Prevents backtrace hanging on ARM Windows targets.

Feel free to use this or something else as you see best.